### PR TITLE
Fix choose font size with a mouse

### DIFF
--- a/src/main/java/com/connectina/swing/SizePane.java
+++ b/src/main/java/com/connectina/swing/SizePane.java
@@ -113,6 +113,9 @@ public class SizePane extends JPanel {
     }
 
     public int getSelectedSize() {
+        if (!sizeList.isSelectionEmpty()) {
+            return sizeList.getSelectedValue();
+        }
         return (Integer) sizeSpinner.getValue();
     }
 


### PR DESCRIPTION
If the size of the font is chosen by clicking with a mouse the size
on the sizelist, the size isn't immediately changed, it comes one
step behind. I.e., if you first choose, let's say 10 and after
that 20, when you click 20, the actual size is changed to 10. You
can see this on the preview and getSelectedFont() returns 10 in this
case too.

The fix tries to get the font size from the sizelist first and if it's
empty, from the spinner.