### PR TITLE
Miscelanious fixes to be more compliant with varias LookAndFeel implementations

### DIFF
--- a/src/main/java/org/drjekyll/fontchooser/FontDialog.java
+++ b/src/main/java/org/drjekyll/fontchooser/FontDialog.java
@@ -157,6 +157,7 @@ public class FontDialog extends JDialog {
                 cancelSelected = true;
             }
         });
+        pack();
     }
 
     private void initComponents() {
@@ -184,8 +185,6 @@ public class FontDialog extends JDialog {
             dispose();
         });
         controlPanel.add(cancelButton);
-
-        pack();
     }
 
     public Font getSelectedFont() {

--- a/src/main/java/org/drjekyll/fontchooser/FontDialog.java
+++ b/src/main/java/org/drjekyll/fontchooser/FontDialog.java
@@ -151,7 +151,6 @@ public class FontDialog extends JDialog {
         initComponents();
         getRootPane().setDefaultButton(okButton);
 
-        cancelButton.addActionListener(event -> cancelSelected = true);
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent e) {

--- a/src/main/java/org/drjekyll/fontchooser/panes/BorderWrapper.java
+++ b/src/main/java/org/drjekyll/fontchooser/panes/BorderWrapper.java
@@ -1,0 +1,33 @@
+package org.drjekyll.fontchooser.panes;
+
+import lombok.RequiredArgsConstructor;
+
+import javax.swing.border.Border;
+import javax.swing.plaf.UIResource;
+import java.awt.*;
+
+@RequiredArgsConstructor
+class BorderWrapper implements Border {
+
+    private final Border border;
+
+    public static Border makeNonUIResource(Border border) {
+        if (border == null || border instanceof UIResource) return null;
+        return new BorderWrapper(border);
+    }
+
+    @Override
+    public void paintBorder(Component c, Graphics g, int x, int y, int width, int height) {
+        border.paintBorder(c, g, x, y, width, height);
+    }
+
+    @Override
+    public Insets getBorderInsets(Component c) {
+        return border.getBorderInsets(c);
+    }
+
+    @Override
+    public boolean isBorderOpaque() {
+        return border.isBorderOpaque();
+    }
+}

--- a/src/main/java/org/drjekyll/fontchooser/panes/PreviewPane.java
+++ b/src/main/java/org/drjekyll/fontchooser/panes/PreviewPane.java
@@ -16,12 +16,23 @@ public class PreviewPane extends JScrollPane {
     public PreviewPane() {
         ResourceBundle resourceBundle = ResourceBundle.getBundle("FontChooser");
         previewText.setText(resourceBundle.getString("font.preview.text"));
+        setPreviewTextBorder();
+        setPreferredSize(new Dimension(200, 80));
+        setViewportView(previewText);
+    }
+
+    @Override
+    public void updateUI() {
+        super.updateUI();
+        setPreviewTextBorder();
+    }
+
+    private void setPreviewTextBorder() {
+        if (previewText == null) return;
         previewText.setBorder(BorderFactory.createCompoundBorder(
             previewText.getBorder(),
             BorderFactory.createEmptyBorder(5, 5, 5, 5))
         );
-        setPreferredSize(new Dimension(200, 80));
-        setViewportView(previewText);
     }
 
     public void setPreviewFont(Font font) {

--- a/src/main/java/org/drjekyll/fontchooser/panes/SizePane.java
+++ b/src/main/java/org/drjekyll/fontchooser/panes/SizePane.java
@@ -79,7 +79,7 @@ public class SizePane extends JPanel {
     private void setupSpinnerEditor(JSpinner spinner) {
         JSpinner.DefaultEditor editor = (JSpinner.DefaultEditor) spinner.getEditor();
         JFormattedTextField textField = editor.getTextField();
-        textField.setBorder(new JScrollPane().getBorder());
+        textField.setBorder(BorderWrapper.makeNonUIResource(new JScrollPane().getBorder()));
     }
 
     private void initSizeList() {

--- a/src/main/java/org/drjekyll/fontchooser/panes/SizePane.java
+++ b/src/main/java/org/drjekyll/fontchooser/panes/SizePane.java
@@ -62,9 +62,7 @@ public class SizePane extends JPanel {
         int spinnerHeight = (int) sizeSpinner.getPreferredSize().getHeight();
         sizeSpinner.setPreferredSize(new Dimension(60, spinnerHeight));
         sizeSpinner.setModel(new SpinnerNumberModel(12, 6, 128, 1));
-        JSpinner.DefaultEditor editor = (JSpinner.DefaultEditor) sizeSpinner.getEditor();
-        JFormattedTextField textField = editor.getTextField();
-        textField.setBorder(new JScrollPane().getBorder());
+        setupSpinnerEditor(sizeSpinner);
         sizeSpinner.addChangeListener(event -> {
 
             Integer value = (Integer) sizeSpinner.getValue();
@@ -76,6 +74,12 @@ public class SizePane extends JPanel {
             }
 
         });
+    }
+
+    private void setupSpinnerEditor(JSpinner spinner) {
+        JSpinner.DefaultEditor editor = (JSpinner.DefaultEditor) spinner.getEditor();
+        JFormattedTextField textField = editor.getTextField();
+        textField.setBorder(new JScrollPane().getBorder());
     }
 
     private void initSizeList() {
@@ -105,6 +109,14 @@ public class SizePane extends JPanel {
             }
             size += step;
         } while (size <= 128);
+    }
+
+    @Override
+    public void updateUI() {
+        super.updateUI();
+        if (sizeSpinner != null){
+            setupSpinnerEditor(sizeSpinner);
+        }
     }
 
     public void addListSelectionListener(ListSelectionListener listener) {


### PR DESCRIPTION
This is a collection of miscellanious fixes I found while implementing a solution for  #2.
See the issue on my rationale on the approach.

All other fixes relate to being able to use `FontChooser` in an application which expects to change its LaF at runtime. Because some components reused properties from the LaF they need to be updated when the LaF changes (i.e. `JComponent#updateUI` is called).
I have also noticed that the `FontDIalog` packed its components to early (before the default button was set), which resulted in incorrect button sizes if the default button appearance makes use of bold text (which is the case e.g. in darklaf). This wouldn't be a big deal if it wouldn't result in the text being clipped and "OK" becoming "...".
